### PR TITLE
Add content accessor to AnsiSequence

### DIFF
--- a/Sources/TerminalOutput/ControlSequences/AnsiSequence.swift
+++ b/Sources/TerminalOutput/ControlSequences/AnsiSequence.swift
@@ -1,0 +1,14 @@
+public struct AnsiSequence : RawRepresentable, ExpressibleByStringLiteral, Equatable {
+  public typealias StringLiteralType = String
+
+  public let rawValue : String
+  public var content  : String { rawValue }
+
+  public init ( rawValue: String ) {
+    self.rawValue = rawValue
+  }
+
+  public init ( stringLiteral value: StringLiteralType ) {
+    self.rawValue = value
+  }
+}

--- a/Tests/TerminalOutputTests/AnsiSequenceTests.swift
+++ b/Tests/TerminalOutputTests/AnsiSequenceTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import TerminalOutput
+
+final class AnsiSequenceTests: XCTestCase {
+  func testContentReturnsStoredRawValue () {
+    let expected = "\u{001B}[0m"
+    let sequence = AnsiSequence ( rawValue: expected )
+
+    XCTAssertEqual ( sequence.content, expected )
+  }
+}


### PR DESCRIPTION
## Summary
- add a ControlSequences module file that defines `AnsiSequence` with a `content` accessor for its stored raw value
- provide tests exercising the new `content` accessor on `AnsiSequence`

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e41420e034832898d027ac662137aa