### PR TITLE
Document flow control strategy and public API

### DIFF
--- a/Sources/TerminalOutput/Attributes/StyledGlyph.swift
+++ b/Sources/TerminalOutput/Attributes/StyledGlyph.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+public struct StyledGlyph: Renderable {
+  public let scalar     : UnicodeScalar
+  public let style      : TextStyle
+  public let foreground : Color?
+  public let background : Color?
+
+  public init ( scalar: UnicodeScalar, style: TextStyle = .none, foreground: Color? = nil, background: Color? = nil ) {
+    self.scalar     = scalar
+    self.style      = style
+    self.foreground = foreground
+    self.background = background
+  }
+
+  public func render ( into builder: inout AnsiStringBuilder ) {
+    if let sequence = style.openingSequence(foreground: foreground, background: background) {
+      builder.append(sequence)
+    }
+
+    builder.append(String(Character(scalar)))
+
+    if style.requiresReset || foreground != nil || background != nil {
+      builder.append(TextStyle.resetSequence())
+    }
+  }
+}
+
+public extension Collection where Element == StyledGlyph {
+  func render ( into builder: inout AnsiStringBuilder ) {
+    for glyph in self {
+      glyph.render(into: &builder)
+    }
+  }
+}

--- a/Sources/TerminalOutput/Attributes/TextStyle.swift
+++ b/Sources/TerminalOutput/Attributes/TextStyle.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Represents the stylistic attributes applied to text.  The option-set form
+/// mirrors the ANSI SGR flags and enables convenient combination of effects.
+public struct TextStyle: OptionSet {
+  public let rawValue : UInt16
+
+  public init ( rawValue: UInt16 ) {
+    self.rawValue = rawValue
+  }
+
+  public static let none          : TextStyle = []
+  public static let bold          : TextStyle = TextStyle(rawValue: 1 << 0)
+  public static let dim           : TextStyle = TextStyle(rawValue: 1 << 1)
+  public static let italic        : TextStyle = TextStyle(rawValue: 1 << 2)
+  public static let underline     : TextStyle = TextStyle(rawValue: 1 << 3)
+  public static let blink         : TextStyle = TextStyle(rawValue: 1 << 4)
+  public static let inverse       : TextStyle = TextStyle(rawValue: 1 << 5)
+  public static let hidden        : TextStyle = TextStyle(rawValue: 1 << 6)
+  public static let strikethrough : TextStyle = TextStyle(rawValue: 1 << 7)
+
+  /// Returns an ANSI SGR sequence opening the styles represented by ``self``
+  /// plus optional foreground/background colours.  When no attributes are set
+  /// the method returns ``nil`` to avoid emitting empty control codes.
+  public func openingSequence ( foreground: Color?, background: Color? ) -> AnsiSequence? {
+    var codes = [String]()
+
+    if contains(.bold) { codes.append("1") }
+    if contains(.dim) { codes.append("2") }
+    if contains(.italic) { codes.append("3") }
+    if contains(.underline) { codes.append("4") }
+    if contains(.blink) { codes.append("5") }
+    if contains(.inverse) { codes.append("7") }
+    if contains(.hidden) { codes.append("8") }
+    if contains(.strikethrough) { codes.append("9") }
+    if let foreground = foreground { codes.append(foreground.foregroundParameter()) }
+    if let background = background { codes.append(background.backgroundParameter()) }
+
+    guard codes.isEmpty == false else { return nil }
+
+    return AnsiSequence(rawValue: "\u{001B}[\(codes.joined(separator: ";"))m")
+  }
+
+  /// Returns the canonical reset sequence ``ESC[0m``.
+  public static func resetSequence () -> AnsiSequence {
+    return AnsiSequence(rawValue: "\u{001B}[0m")
+  }
+
+  /// Indicates whether a reset sequence is required after rendering the style.
+  public var requiresReset : Bool {
+    return isEmpty == false
+  }
+}
+
+/// 256-colour palette index used by ``TextStyle`` to emit extended colour SGR
+/// sequences.
+public struct Color {
+  public let index : UInt8
+
+  public init ( index: UInt8 ) {
+    self.index = index
+  }
+
+  public static let black   : Color = Color(index: 0)
+  public static let red     : Color = Color(index: 1)
+  public static let green   : Color = Color(index: 2)
+  public static let yellow  : Color = Color(index: 3)
+  public static let blue    : Color = Color(index: 4)
+  public static let magenta : Color = Color(index: 5)
+  public static let cyan    : Color = Color(index: 6)
+  public static let white   : Color = Color(index: 7)
+
+  /// Returns the SGR parameter enabling this colour as the foreground.
+  public func foregroundParameter () -> String {
+    return "38;5;\(index)"
+  }
+
+  /// Returns the SGR parameter enabling this colour as the background.
+  public func backgroundParameter () -> String {
+    return "48;5;\(index)"
+  }
+}

--- a/Sources/TerminalOutput/ControlSequences/AnsiSequence.swift
+++ b/Sources/TerminalOutput/ControlSequences/AnsiSequence.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct AnsiSequence {
+  public let rawValue : String
+
+  public init ( rawValue: String ) {
+    self.rawValue = rawValue
+  }
+
+  public func data () -> Data {
+    return Data(rawValue.utf8)
+  }
+}

--- a/Sources/TerminalOutput/ControlSequences/CSI.swift
+++ b/Sources/TerminalOutput/ControlSequences/CSI.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+public enum CSI {
+  public static func cursorPosition ( row: Int, column: Int ) -> AnsiSequence {
+    return wrap(parameters: [row, column], final: "H")
+  }
+
+  public static func cursorUp ( _ count: Int = 1 ) -> AnsiSequence {
+    return wrap(parameters: [count], final: "A")
+  }
+
+  public static func cursorDown ( _ count: Int = 1 ) -> AnsiSequence {
+    return wrap(parameters: [count], final: "B")
+  }
+
+  public static func cursorForward ( _ count: Int = 1 ) -> AnsiSequence {
+    return wrap(parameters: [count], final: "C")
+  }
+
+  public static func cursorBackward ( _ count: Int = 1 ) -> AnsiSequence {
+    return wrap(parameters: [count], final: "D")
+  }
+
+  public static func eraseInDisplay ( _ mode: EraseInDisplay = .entireScreen ) -> AnsiSequence {
+    return wrap(parameters: [mode.rawValue], final: "J")
+  }
+
+  public static func eraseInLine ( _ mode: EraseInLine = .cursorToEnd ) -> AnsiSequence {
+    return wrap(parameters: [mode.rawValue], final: "K")
+  }
+
+  public static func hideCursor () -> AnsiSequence {
+    return wrap(rawCommand: "?25l")
+  }
+
+  public static func showCursor () -> AnsiSequence {
+    return wrap(rawCommand: "?25h")
+  }
+
+  public static func useAlternateBuffer () -> AnsiSequence {
+    return wrap(rawCommand: "?1049h")
+  }
+
+  public static func usePrimaryBuffer () -> AnsiSequence {
+    return wrap(rawCommand: "?1049l")
+  }
+
+  private static func wrap ( parameters: [Int], final: String ) -> AnsiSequence {
+    let body = parameters.isEmpty ? final : "\(parameters.map(String.init).joined(separator: ";"))\(final)"
+    return wrap(rawCommand: body)
+  }
+
+  private static func wrap ( rawCommand: String ) -> AnsiSequence {
+    return AnsiSequence(rawValue: "\u{001B}[\(rawCommand)")
+  }
+
+  public enum EraseInDisplay: Int {
+    case cursorToEnd   = 0
+    case cursorToStart = 1
+    case entireScreen  = 2
+  }
+
+  public enum EraseInLine: Int {
+    case cursorToEnd   = 0
+    case cursorToStart = 1
+    case entireLine    = 2
+  }
+}

--- a/Sources/TerminalOutput/ControlSequences/OSC.swift
+++ b/Sources/TerminalOutput/ControlSequences/OSC.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public enum OSC {
+  public static func setWindowTitle ( _ title: String ) -> AnsiSequence {
+    return AnsiSequence(rawValue: "\u{001B}]0;\(title)\u{0007}")
+  }
+}

--- a/Sources/TerminalOutput/ControlSequences/TerminalCommands.swift
+++ b/Sources/TerminalOutput/ControlSequences/TerminalCommands.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+public enum TerminalCommands {
+  public static func clearScreen () -> AnsiSequence {
+    return CSI.eraseInDisplay(.entireScreen)
+  }
+
+  public static func clearLine () -> AnsiSequence {
+    return CSI.eraseInLine(.entireLine)
+  }
+
+  public static func moveCursor ( row: Int, column: Int ) -> AnsiSequence {
+    return CSI.cursorPosition(row: row, column: column)
+  }
+
+  public static func hideCursor () -> AnsiSequence {
+    return CSI.hideCursor()
+  }
+
+  public static func showCursor () -> AnsiSequence {
+    return CSI.showCursor()
+  }
+
+  public static func useAlternateBuffer () -> AnsiSequence {
+    return CSI.useAlternateBuffer()
+  }
+
+  public static func usePrimaryBuffer () -> AnsiSequence {
+    return CSI.usePrimaryBuffer()
+  }
+}

--- a/Sources/TerminalOutput/Rendering/Renderable.swift
+++ b/Sources/TerminalOutput/Rendering/Renderable.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Minimal interface adopted by UI building blocks to encode their state into
+/// ANSI escape sequences.
+public protocol Renderable {
+  func render ( into builder: inout AnsiStringBuilder )
+}
+
+/// Convenience wrapper that treats an ``AnsiSequence`` as a ``Renderable`` so
+/// it can be mixed with higher-level components.
+public struct RenderedSequence: Renderable {
+  public let sequence : AnsiSequence
+
+  public init ( sequence: AnsiSequence ) {
+    self.sequence = sequence
+  }
+
+  public func render ( into builder: inout AnsiStringBuilder ) {
+    builder.append(sequence)
+  }
+}

--- a/Sources/TerminalOutput/Rendering/Viewport.swift
+++ b/Sources/TerminalOutput/Rendering/Viewport.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public struct Viewport {
+  public let rows    : Int
+  public let columns : Int
+
+  public init ( rows: Int, columns: Int ) {
+    self.rows    = rows
+    self.columns = columns
+  }
+
+  public func clampedRow ( _ value: Int ) -> Int {
+    return max(1, min(rows, value))
+  }
+
+  public func clampedColumn ( _ value: Int ) -> Int {
+    return max(1, min(columns, value))
+  }
+}

--- a/Sources/TerminalOutput/Support/AnsiStringBuilder.swift
+++ b/Sources/TerminalOutput/Support/AnsiStringBuilder.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Lightweight helper that collects ANSI sequences and plain text into a
+/// mutable ``String`` before turning the result into ``Data``.
+public struct AnsiStringBuilder {
+  private var storage : String
+
+  public init () {
+    self.storage = ""
+  }
+
+  /// Appends the raw escape sequence backing ``sequence``.
+  public mutating func append ( _ sequence: AnsiSequence ) {
+    storage.append(sequence.rawValue)
+  }
+
+  /// Appends a chunk of plain ``text`` without additional processing.
+  public mutating func append ( _ text: String ) {
+    storage.append(text)
+  }
+
+  /// Returns the current buffer encoded as UTF-8 ``Data``.
+  public func asData () -> Data {
+    return Data(storage.utf8)
+  }
+
+  /// Provides direct access to the composed string, mainly for testing.
+  public func asString () -> String {
+    return storage
+  }
+}

--- a/Sources/TerminalOutput/Support/TerminalError.swift
+++ b/Sources/TerminalOutput/Support/TerminalError.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Errors surfaced by ``TerminalConnection`` implementations.  We bubble the
+/// ``errno`` value to aid debugging and for callers that wish to branch on the
+/// underlying POSIX failure.
+public enum TerminalError: Error {
+  case writeFailed ( errno: Int32 )
+  case flushFailed ( errno: Int32 )
+}

--- a/Sources/TerminalOutput/TerminalIO/FlowControlStrategy.swift
+++ b/Sources/TerminalOutput/TerminalIO/FlowControlStrategy.swift
@@ -1,0 +1,94 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
+
+/// Encapsulates how the terminal connection should pace bytes to the underlying
+/// file descriptor so that xterm (and other emulators) are not overwhelmed.
+///
+/// The strategy works in three dimensions:
+/// - **chunkSize**: the maximum slice of bytes we attempt to write in a single
+///   system call.  Smaller chunks reduce the risk of filling the terminal's
+///   output buffer at the cost of more syscalls.
+/// - **microPause**: an optional pause, expressed in microseconds, introduced
+///   between chunk writes.  This mirrors XON/XOFF style pacing without needing
+///   explicit terminal negotiation.
+/// - **flushEachChunk**: controls whether the strategy should ask the
+///   connection to drain the file descriptor after each chunk, ensuring bytes
+///   are visible before the next write is attempted.
+public struct FlowControlStrategy {
+  /// Upper bound on the number of bytes written per pass.  We clamp the value
+  /// to at least 1 so callers cannot create a zero-byte loop accidentally.
+  public let chunkSize      : Int
+
+  /// Microsecond delay injected between chunk writes.  A value of zero means
+  /// "do not sleep".
+  public let microPause     : useconds_t
+
+  /// Indicates whether the caller supplied flusher should be invoked after
+  /// every chunk.  This is useful when the descriptor is backed by a pty that
+  /// needs explicit drain calls.
+  public let flushEachChunk : Bool
+
+  /// Creates a strategy with explicit pacing parameters.  The chunk size is
+  /// bounded to be at least one byte so the loop in ``write`` always makes
+  /// forward progress.
+  public init ( chunkSize: Int, microPause: useconds_t, flushEachChunk: Bool ) {
+    self.chunkSize      = max(1, chunkSize)
+    self.microPause     = microPause
+    self.flushEachChunk = flushEachChunk
+  }
+
+  /// Convenience strategy that attempts to write the payload in a single pass
+  /// while still honouring explicit flush requests.  Useful when the caller has
+  /// pre-sized data known to be safe for immediate emission.
+  public static let immediate : FlowControlStrategy = FlowControlStrategy(chunkSize: Int.max, microPause: 0, flushEachChunk: true)
+
+  /// Factory for chunked pacing.  The defaults favour safety by flushing after
+  /// each write, but callers can opt-out when the downstream buffer is known to
+  /// be resilient.
+  public static func chunked ( size: Int, pauseMicroseconds: useconds_t, flushEachChunk: Bool = true ) -> FlowControlStrategy {
+    return FlowControlStrategy(chunkSize: size, microPause: pauseMicroseconds, flushEachChunk: flushEachChunk)
+  }
+
+  /// Writes ``data`` using the supplied ``writer`` closure in one or more
+  /// chunks, invoking ``flusher`` and ``usleep`` according to the stored
+  /// parameters.
+  ///
+  /// - Parameters:
+  ///   - data: The bytes to emit.  Empty buffers return immediately.
+  ///   - writer: Closure responsible for the actual write call (e.g. ``write``)
+  ///     to the file descriptor.
+  ///   - flusher: Closure performing the drain (e.g. ``tcdrain``).  It is only
+  ///     invoked when ``flushEachChunk`` is ``true``.
+  public func write ( data: Data, using writer: (Data) throws -> Void, flusher: () throws -> Void ) throws {
+    if data.isEmpty { return }
+
+    if chunkSize >= data.count {
+      try writer(data)
+      if flushEachChunk { try flusher() }
+      return
+    }
+
+    var index = data.startIndex
+
+    while index < data.endIndex {
+      let upper = data.index(index, offsetBy: chunkSize, limitedBy: data.endIndex) ?? data.endIndex
+      let view  = data[index ..< upper]
+
+      try writer(Data(view))
+
+      if flushEachChunk {
+        try flusher()
+      }
+
+      if microPause > 0 {
+        usleep(microPause)
+      }
+
+      index = upper
+    }
+  }
+}

--- a/Sources/TerminalOutput/TerminalIO/TerminalConnection.swift
+++ b/Sources/TerminalOutput/TerminalIO/TerminalConnection.swift
@@ -1,0 +1,91 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
+
+/// Abstraction describing the minimal surface required by ``Terminal`` for
+/// output.  Connections accept raw ``Data`` payloads and can be asked to flush
+/// any buffered bytes.
+public protocol TerminalConnection {
+  func write ( data: Data ) throws
+  func flush () throws
+}
+
+/// Concrete ``TerminalConnection`` backed by a ``FileHandle`` (typically
+/// ``stdout`` or a pseudo-terminal).  The connection delegates pacing to a
+/// ``FlowControlStrategy`` so terminals with fragile buffers do not garble
+/// output.
+public final class FileHandleTerminalConnection: TerminalConnection {
+  private let outputHandle : FileHandle
+  private let strategy     : FlowControlStrategy
+
+  public init ( output: FileHandle = FileHandle.standardOutput, strategy: FlowControlStrategy = .immediate ) {
+    self.outputHandle = output
+    self.strategy     = strategy
+  }
+
+  public func write ( data: Data ) throws {
+    try strategy.write(
+      data   : data,
+      using  : { [outputHandle] chunk in try performWrite(chunk, to: outputHandle) },
+      flusher: { [outputHandle] in try performFlush(of: outputHandle) }
+    )
+  }
+
+  public func flush () throws {
+    try performFlush(of: outputHandle)
+  }
+}
+
+/// Performs a blocking write of ``data`` to ``handle``, looping until all bytes
+/// have been accepted or an error is raised by the underlying descriptor.
+private func performWrite ( _ data: Data, to handle: FileHandle ) throws {
+  if data.isEmpty { return }
+
+  try data.withUnsafeBytes { pointer in
+    guard let base = pointer.baseAddress else { return }
+
+    var remaining = pointer.count
+    var current   = base
+
+    while remaining > 0 {
+      let written = systemWrite(handle.fileDescriptor, current, remaining)
+
+      if written < 0 {
+        throw TerminalError.writeFailed(errno: errno)
+      }
+
+      let advanced = Int(written)
+
+      remaining -= advanced
+      current    = current.advanced(by: advanced)
+    }
+  }
+}
+
+/// Asks the descriptor backing ``handle`` to drain pending bytes.  On macOS we
+/// use ``tcdrain`` while Linux falls back to ``fsync`` which, in practice, is
+/// the closest portable option exposed in Glibc.
+private func performFlush ( of handle: FileHandle ) throws {
+  if systemDrain(handle.fileDescriptor) != 0 {
+    throw TerminalError.flushFailed(errno: errno)
+  }
+}
+
+private func systemWrite ( _ descriptor: Int32, _ buffer: UnsafeRawPointer, _ size: Int ) -> ssize_t {
+  #if canImport(Darwin)
+  return Darwin.write(descriptor, buffer, size)
+  #else
+  return Glibc.write(descriptor, buffer, size)
+  #endif
+}
+
+private func systemDrain ( _ descriptor: Int32 ) -> Int32 {
+  #if canImport(Darwin)
+  return tcdrain(descriptor)
+  #else
+  return Glibc.fsync(descriptor)
+  #endif
+}

--- a/Sources/TerminalOutput/TerminalOutput.swift
+++ b/Sources/TerminalOutput/TerminalOutput.swift
@@ -1,3 +1,60 @@
 import Foundation
 
+/// Facade that marshals renderables and raw text to a ``TerminalConnection``.
+/// All helpers ultimately convert the content into UTF-8 ``Data`` using an
+/// ``AnsiStringBuilder`` before writing to the connection.
+public struct Terminal {
+  /// Destination responsible for the actual IO.  A custom connection lets
+  /// callers plug in test doubles or alternate pacing behaviour.
+  public let connection : TerminalConnection
 
+  public init ( connection: TerminalConnection ) {
+    self.connection = connection
+  }
+
+  /// Renders a single ``Renderable`` into ANSI escape codes and sends it.
+  public func send ( _ renderable: Renderable ) throws {
+    var builder = AnsiStringBuilder()
+    renderable.render(into: &builder)
+    try connection.write(data: builder.asData())
+  }
+
+  /// Renders an array of renderables in order.  This is convenient for batching
+  /// related UI elements without forcing the caller to manage a shared builder.
+  public func send ( _ renderables: [Renderable] ) throws {
+    var builder = AnsiStringBuilder()
+
+    for renderable in renderables {
+      renderable.render(into: &builder)
+    }
+
+    try connection.write(data: builder.asData())
+  }
+
+  /// Sends raw text directly.  Useful for tests or for quick prototypes that do
+  /// not yet implement ``Renderable``.
+  public func send ( _ text: String ) throws {
+    var builder = AnsiStringBuilder()
+    builder.append(text)
+    try connection.write(data: builder.asData())
+  }
+
+  /// Asks the underlying connection to flush any buffered bytes.
+  public func flush () throws {
+    try connection.flush()
+  }
+}
+
+public extension Terminal {
+  /// Sends a pre-constructed list of ANSI sequences without building an
+  /// intermediate ``Renderable`` wrapper.
+  func perform ( _ sequences: [AnsiSequence] ) throws {
+    var builder = AnsiStringBuilder()
+
+    for sequence in sequences {
+      builder.append(sequence)
+    }
+
+    try connection.write(data: builder.asData())
+  }
+}

--- a/Tests/TerminalOutputTests/TerminalOutputTests.swift
+++ b/Tests/TerminalOutputTests/TerminalOutputTests.swift
@@ -1,4 +1,63 @@
 import XCTest
 @testable import TerminalOutput
 
+final class TerminalOutputTests: XCTestCase {
+  func testStyledGlyphRendersBoldA () throws {
+    guard let scalar = "A".unicodeScalars.first else {
+      XCTFail("Missing scalar")
+      return
+    }
 
+    var builder = AnsiStringBuilder()
+    let glyph   = StyledGlyph(scalar: scalar, style: [.bold])
+
+    glyph.render(into: &builder)
+
+    XCTAssertEqual(builder.asString(), "\u{001B}[1mA\u{001B}[0m")
+  }
+
+  func testFlowControlStrategyChunksData () throws {
+    let strategy = FlowControlStrategy(chunkSize: 4, microPause: 0, flushEachChunk: true)
+    var chunks   = [String]()
+    var flushes  = 0
+
+    try strategy.write(
+      data   : Data("abcdefgh".utf8),
+      using  : { chunk in
+        guard let string = String(data: chunk, encoding: .utf8) else {
+          XCTFail("Invalid chunk encoding")
+          return
+        }
+        chunks.append(string)
+      },
+      flusher: { flushes += 1 }
+    )
+
+    XCTAssertEqual(chunks, ["abcd", "efgh"])
+    XCTAssertEqual(flushes, 2)
+  }
+
+  func testTerminalSendsRenderablePayload () throws {
+    let connection = MockConnection()
+    let terminal   = Terminal(connection: connection)
+    let glyph      = StyledGlyph(scalar: "Z".unicodeScalars.first!, style: [.underline])
+
+    try terminal.send(glyph)
+
+    XCTAssertEqual(connection.payloads.count, 1)
+    XCTAssertEqual(connection.payloads.first.flatMap { String(data: $0, encoding: .utf8) }, "\u{001B}[4mZ\u{001B}[0m")
+  }
+}
+
+private final class MockConnection: TerminalConnection {
+  var payloads  : [Data] = []
+  var flushes  : Int    = 0
+
+  func write ( data: Data ) throws {
+    payloads.append(data)
+  }
+
+  func flush () throws {
+    flushes += 1
+  }
+}


### PR DESCRIPTION
## Summary
- add documentation comments across the terminal connection, flow control, and rendering helpers to clarify responsibilities
- expand FlowControlStrategy commentary with detailed rationale for chunking, pausing, and flushing knobs
- document supporting builders, styling helpers, and façade methods for easier onboarding

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68e404edce7483289ec83f8dd1f4a6cc