### PR TITLE
Introduce TerminalCommand DSL for ANSI control sequences

### DIFF
--- a/Sources/TerminalOutput/ControlSequences/AnsiSequence.swift
+++ b/Sources/TerminalOutput/ControlSequences/AnsiSequence.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+public struct AnsiSequence : Equatable, Hashable, ExpressibleByStringLiteral, ExpressibleByExtendedGraphemeClusterLiteral, ExpressibleByUnicodeScalarLiteral, ExpressibleByArrayLiteral, CustomStringConvertible {
+  public typealias ArrayLiteralElement = AnsiSequence
+
+  public let rawValue : String
+
+  public init ( _ rawValue: String ) {
+    self.rawValue = rawValue
+  }
+
+  public init ( stringLiteral value: StringLiteralType ) {
+    self.init(value)
+  }
+
+  public init ( extendedGraphemeClusterLiteral value: StringLiteralType ) {
+    self.init(value)
+  }
+
+  public init ( unicodeScalarLiteral value: StringLiteralType ) {
+    self.init(value)
+  }
+
+  public init ( arrayLiteral elements: AnsiSequence... ) {
+    self.init(elements.map { $0.rawValue }.joined())
+  }
+
+  public var description : String { rawValue }
+
+  public static func + ( lhs: AnsiSequence, rhs: AnsiSequence ) -> AnsiSequence {
+    AnsiSequence(lhs.rawValue + rhs.rawValue)
+  }
+}
+
+public extension AnsiSequence {
+  static func from ( _ command: TerminalCommand ) -> AnsiSequence {
+    command.sequence
+  }
+
+  static func from ( _ commands: [TerminalCommand] ) -> AnsiSequence {
+    AnsiSequence(commands.map { $0.sequence.rawValue }.joined())
+  }
+}

--- a/Sources/TerminalOutput/ControlSequences/TerminalCommand.swift
+++ b/Sources/TerminalOutput/ControlSequences/TerminalCommand.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+private let controlSequenceIntroducer : String = "\u{001B}["
+private let operatingSystemCommand    : String = "\u{001B}]"
+private let bellTermination           : String = "\u{0007}"
+
+public enum TerminalCommand : Equatable {
+  public enum EraseDisplayMode : Int {
+    case cursorToEnd             = 0
+    case cursorToBeginning       = 1
+    case entireScreen            = 2
+    case entireScreenAndScrollback = 3
+  }
+
+  public enum EraseLineMode : Int {
+    case cursorToEnd       = 0
+    case cursorToBeginning = 1
+    case entireLine        = 2
+  }
+
+  public enum ScreenBuffer {
+    case primary
+    case alternate
+  }
+
+  case cursorUp ( Int )
+  case cursorDown ( Int )
+  case cursorForward ( Int )
+  case cursorBack ( Int )
+  case cursorNextLine ( Int )
+  case cursorPreviousLine ( Int )
+  case cursorHorizontalAbsolute ( Int )
+  case cursorPosition ( row: Int, column: Int )
+  case saveCursorPosition
+  case restoreCursorPosition
+  case hideCursor
+  case showCursor
+  case eraseDisplay ( EraseDisplayMode )
+  case eraseLine ( EraseLineMode )
+  case scrollUp ( Int )
+  case scrollDown ( Int )
+  case selectScreenBuffer ( ScreenBuffer )
+  case setWindowTitle ( String )
+
+  public static var saveCursor : TerminalCommand { .saveCursorPosition }
+  public static var restoreCursor : TerminalCommand { .restoreCursorPosition }
+  public static var hideCursorCommand : TerminalCommand { .hideCursor }
+  public static var showCursorCommand : TerminalCommand { .showCursor }
+  public static var clearScreen : TerminalCommand { .eraseDisplay(.entireScreen) }
+  public static var clearScrollback : TerminalCommand { .eraseDisplay(.entireScreenAndScrollback) }
+  public static var clearLine : TerminalCommand { .eraseLine(.entireLine) }
+  public static var usePrimaryScreenBuffer : TerminalCommand { .selectScreenBuffer(.primary) }
+  public static var useAlternateScreenBuffer : TerminalCommand { .selectScreenBuffer(.alternate) }
+
+  public var sequence : AnsiSequence {
+    switch self {
+      case .cursorUp(let amount)                  : return csi(parameters: [normalized(amount)], terminator: "A")
+      case .cursorDown(let amount)                : return csi(parameters: [normalized(amount)], terminator: "B")
+      case .cursorForward(let amount)             : return csi(parameters: [normalized(amount)], terminator: "C")
+      case .cursorBack(let amount)                : return csi(parameters: [normalized(amount)], terminator: "D")
+      case .cursorNextLine(let amount)            : return csi(parameters: [normalized(amount)], terminator: "E")
+      case .cursorPreviousLine(let amount)        : return csi(parameters: [normalized(amount)], terminator: "F")
+      case .cursorHorizontalAbsolute(let column)  : return csi(parameters: [normalized(column)], terminator: "G")
+      case .cursorPosition(let row, let column)   : return csi(parameters: [normalized(row), normalized(column)], terminator: "H")
+      case .saveCursorPosition                    : return csi(parameters: [], terminator: "s")
+      case .restoreCursorPosition                 : return csi(parameters: [], terminator: "u")
+      case .hideCursor                            : return csi(parameters: ["?25"], terminator: "l")
+      case .showCursor                            : return csi(parameters: ["?25"], terminator: "h")
+      case .eraseDisplay(let mode)                : return csi(parameters: [String(mode.rawValue)], terminator: "J")
+      case .eraseLine(let mode)                   : return csi(parameters: [String(mode.rawValue)], terminator: "K")
+      case .scrollUp(let amount)                  : return csi(parameters: [normalized(amount)], terminator: "S")
+      case .scrollDown(let amount)                : return csi(parameters: [normalized(amount)], terminator: "T")
+      case .selectScreenBuffer(let buffer)        : return bufferSequence(buffer)
+      case .setWindowTitle(let title)             : return osc(payload: "2;\(title)")
+    }
+  }
+}
+
+private func normalized ( _ amount: Int ) -> String {
+  let value = max(1, amount)
+  return String(value)
+}
+
+private func csi ( parameters: [String], terminator: Character ) -> AnsiSequence {
+  let parameterString = parameters.isEmpty ? "" : parameters.joined(separator: ";")
+  return AnsiSequence(controlSequenceIntroducer + parameterString + String(terminator))
+}
+
+private func osc ( payload: String ) -> AnsiSequence {
+  return AnsiSequence(operatingSystemCommand + payload + bellTermination)
+}
+
+private func bufferSequence ( _ buffer: TerminalCommand.ScreenBuffer ) -> AnsiSequence {
+  switch buffer {
+    case .primary  : return csi(parameters: ["?1049"], terminator: "l")
+    case .alternate: return csi(parameters: ["?1049"], terminator: "h")
+  }
+}

--- a/Tests/TerminalOutputTests/TerminalCommandTests.swift
+++ b/Tests/TerminalOutputTests/TerminalCommandTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import TerminalOutput
+
+final class TerminalCommandTests : XCTestCase {
+  func testCursorMovementSequences () {
+    let commands : [TerminalCommand] = [
+      .cursorUp(3),
+      .cursorDown(2),
+      .cursorForward(5),
+      .cursorBack(4),
+      .cursorNextLine(6),
+      .cursorPreviousLine(7),
+      .cursorHorizontalAbsolute(12),
+      .cursorPosition(row: 9, column: 3)
+    ]
+
+    let sequences = commands.map { $0.sequence.rawValue }
+
+    XCTAssertEqual(sequences[0], "\u{001B}[3A")
+    XCTAssertEqual(sequences[1], "\u{001B}[2B")
+    XCTAssertEqual(sequences[2], "\u{001B}[5C")
+    XCTAssertEqual(sequences[3], "\u{001B}[4D")
+    XCTAssertEqual(sequences[4], "\u{001B}[6E")
+    XCTAssertEqual(sequences[5], "\u{001B}[7F")
+    XCTAssertEqual(sequences[6], "\u{001B}[12G")
+    XCTAssertEqual(sequences[7], "\u{001B}[9;3H")
+  }
+
+  func testCursorVisibilityAndPersistenceCommands () {
+    XCTAssertEqual(TerminalCommand.saveCursor.sequence.rawValue, "\u{001B}[s")
+    XCTAssertEqual(TerminalCommand.restoreCursor.sequence.rawValue, "\u{001B}[u")
+    XCTAssertEqual(TerminalCommand.hideCursorCommand.sequence.rawValue, "\u{001B}[?25l")
+    XCTAssertEqual(TerminalCommand.showCursorCommand.sequence.rawValue, "\u{001B}[?25h")
+  }
+
+  func testEraseAndScrollCommands () {
+    XCTAssertEqual(TerminalCommand.clearScreen.sequence.rawValue, "\u{001B}[2J")
+    XCTAssertEqual(TerminalCommand.clearScrollback.sequence.rawValue, "\u{001B}[3J")
+    XCTAssertEqual(TerminalCommand.clearLine.sequence.rawValue, "\u{001B}[2K")
+    XCTAssertEqual(TerminalCommand.scrollUp(10).sequence.rawValue, "\u{001B}[10S")
+    XCTAssertEqual(TerminalCommand.scrollDown(4).sequence.rawValue, "\u{001B}[4T")
+  }
+
+  func testBufferSelection () {
+    XCTAssertEqual(TerminalCommand.useAlternateScreenBuffer.sequence.rawValue, "\u{001B}[?1049h")
+    XCTAssertEqual(TerminalCommand.usePrimaryScreenBuffer.sequence.rawValue, "\u{001B}[?1049l")
+  }
+
+  func testWindowTitle () {
+    XCTAssertEqual(TerminalCommand.setWindowTitle("Hello").sequence.rawValue, "\u{001B}]2;Hello\u{0007}")
+  }
+
+  func testAnsiSequenceBridging () {
+    let combined = AnsiSequence.from([
+      .cursorUp(1),
+      .cursorDown(1),
+      .setWindowTitle("Combined")
+    ])
+
+    XCTAssertEqual(combined.rawValue, "\u{001B}[1A\u{001B}[1B\u{001B}]2;Combined\u{0007}")
+  }
+}


### PR DESCRIPTION
## Summary
- add AnsiSequence utility type and new TerminalCommand enum to model CSI/OSC control sequences
- provide bridging helpers so TerminalCommand instances produce AnsiSequence values and compose together
- cover DSL behavior with unit tests for cursor, erase, buffer, and window title commands

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e40e0be8b88328ab0cef86ae4c6756