### PR TITLE
Remove CustomStringConvertible from AnsiSequence

### DIFF
--- a/Sources/TerminalOutput/ControlSequences/AnsiSequence.swift
+++ b/Sources/TerminalOutput/ControlSequences/AnsiSequence.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public struct AnsiSequence : Equatable, Hashable, ExpressibleByStringLiteral, ExpressibleByArrayLiteral {
+  public typealias ArrayLiteralElement = UInt8
+
+  public let bytes : [UInt8]
+
+  public init ( bytes: [UInt8] ) {
+    self.bytes = bytes
+  }
+
+  public init ( arrayLiteral elements: UInt8... ) {
+    self.bytes = elements
+  }
+
+  public init ( stringLiteral value: String ) {
+    self.bytes = Array(value.utf8)
+  }
+}


### PR DESCRIPTION
## Summary
- add the ControlSequences/AnsiSequence.swift implementation without CustomStringConvertible conformance or description

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e4130fbb088328b78b7a5fdb5f2bca