### PR TITLE
Fix ANSI sequence construction and bridging

### DIFF
--- a/Sources/TerminalOutput/ControlSequences/AnsiSequence.swift
+++ b/Sources/TerminalOutput/ControlSequences/AnsiSequence.swift
@@ -11,4 +11,9 @@ public struct AnsiSequence : RawRepresentable, ExpressibleByStringLiteral, Equat
   public init ( stringLiteral value: StringLiteralType ) {
     self.rawValue = value
   }
+
+  public static func from ( _ commands: [TerminalCommand] ) -> AnsiSequence {
+    let combined = commands.map { $0.sequence.rawValue }.joined()
+    return AnsiSequence(rawValue: combined)
+  }
 }

--- a/Sources/TerminalOutput/ControlSequences/TerminalCommand.swift
+++ b/Sources/TerminalOutput/ControlSequences/TerminalCommand.swift
@@ -83,11 +83,11 @@ private func normalized ( _ amount: Int ) -> String {
 
 private func csi ( parameters: [String], terminator: Character ) -> AnsiSequence {
   let parameterString = parameters.isEmpty ? "" : parameters.joined(separator: ";")
-  return AnsiSequence(controlSequenceIntroducer + parameterString + String(terminator))
+  return AnsiSequence(rawValue: controlSequenceIntroducer + parameterString + String(terminator))
 }
 
 private func osc ( payload: String ) -> AnsiSequence {
-  return AnsiSequence(operatingSystemCommand + payload + bellTermination)
+  return AnsiSequence(rawValue: operatingSystemCommand + payload + bellTermination)
 }
 
 private func bufferSequence ( _ buffer: TerminalCommand.ScreenBuffer ) -> AnsiSequence {


### PR DESCRIPTION
## Summary
- fix TerminalCommand helpers to use the labeled AnsiSequence initializer so the package builds again
- add an AnsiSequence convenience to concatenate multiple terminal commands for the tests

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68e41ceb9e9c832883a9d48837a1e690